### PR TITLE
【Fixed】タグ一覧からタグに紐づく質問を検索出来るようにする。

### DIFF
--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,3 +1,15 @@
 // Place all the styles related to the tags controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.tag_list{
+  margin: 20px;
+  background-color: #ffffff;
+}
+.tag{
+  font-size: 30px;
+  line-height: 50px;
+}
+.tag_area{
+  font-size: 10px;
+  margin: 10px;
+}

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -12,6 +12,11 @@
           <br/>
           <span class="glyphicon glyphicon-arrow-down">投票下ボタン
             <p class="index_main_question_block_content"><%= link_to question.title, question %></p>
+            <div class="tag_area" >
+              <% question.tag_list.each do |tag| %>
+                <span class="label label-info"><%= tag %></span>
+              <% end %>
+            </div>
           </span>
           <!-- 作成者の質問の編集と破棄が可能　-->
           <% if question.user_id == current_user.id %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -16,6 +16,11 @@
           <span class="glyphicon glyphicon-arrow-down">投票下ボタン
             <p class="index_main_question_block_content"><%= @question.content %>
           </span>
+          <div class="tag_area">
+            <% @question.tag_list.each do |tag| %>
+              <span class="label label-info"><%= tag %></span>
+            <% end %>
+          </div>
             <p> <%= @question.user.name %>さん</p>
           <!-- <%#= link_to '詳細へ', question %> -->
           <!-- 作成者の質問の編集と破棄が可能　-->

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,6 +1,8 @@
-<h1>Tag一覧</h1>
-<div class="tag_list">
-  <% @tags.each do |tag| %>
-    <p><%= tag.name %> </p>
-  <% end %>
+<div class="container">
+  <h1>Tag一覧</h1>
+  <div class="tag_list">
+    <% @tags.each do |tag| %>
+      <span class="tag"><%= link_to tag.name,questions_path(tags: tag.name), class: "label label-info" %> </span>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
#38  
* タグ名をテキストではなく、リンクに変更
* タグ名をClick時にタグ名で検索した質問一覧へ遷移
* タグ一覧、質問一覧、質問詳細のレイアウトを微修正